### PR TITLE
Convert Lists to Sets

### DIFF
--- a/src/dls_bluesky_core/plans/scanspec.py
+++ b/src/dls_bluesky_core/plans/scanspec.py
@@ -1,6 +1,6 @@
 import operator
 from functools import reduce
-from typing import Any, List, Mapping, Optional
+from typing import Any, Mapping, Optional
 
 import bluesky.plans as bp
 from bluesky.protocols import Movable, Readable
@@ -17,7 +17,7 @@ Diamond's "mapping scans" using ScanPointGenerator.
 
 
 def scan(
-    detectors: List[Readable],
+    detectors: set[Readable],
     axes_to_move: Mapping[str, Movable],
     spec: Spec[str],
     metadata: Optional[Mapping[str, Any]] = None,
@@ -26,7 +26,7 @@ def scan(
     Scan wrapping `bp.scan_nd`
 
     Args:
-        detectors: List of readable devices, will take a reading at
+        detectors: Set of readable devices, will take a reading at
                                     each point
         axes_to_move: All axes involved in this scan, names and
             objects
@@ -44,7 +44,7 @@ def scan(
 
     _md = {
         "plan_args": {
-            "detectors": list(map(repr, detectors)),
+            "detectors": set(map(repr, detectors)),
             "axes_to_move": {k: repr(v) for k, v in axes_to_move.items()},
             "spec": repr(spec),
         },

--- a/src/dls_bluesky_core/plans/wrapped.py
+++ b/src/dls_bluesky_core/plans/wrapped.py
@@ -34,16 +34,5 @@ def count(
     Yields:
         Iterator[MsgGenerator]: _description_
     """
-    plan_args = {
-        # If bp.count added delay to plan_args, we could remove all md handling
-        "detectors": set(map(repr, detectors)),
-        "num": num,
-        "delay": delay,
-    }
 
-    _md = {
-        "plan_args": plan_args,
-        **(metadata or {}),
-    }
-
-    yield from bp.count(detectors, num, delay=delay, md=_md)
+    yield from bp.count(detectors, num, delay=delay, md=metadata or {})

--- a/src/dls_bluesky_core/plans/wrapped.py
+++ b/src/dls_bluesky_core/plans/wrapped.py
@@ -11,7 +11,7 @@ Wrappers for Bluesky built-in plans with type hinting and renamed metadata
 
 
 def count(
-    detectors: List[Readable],
+    detectors: set[Readable],
     num: int = 1,
     delay: Optional[Union[float, List[float]]] = None,
     metadata: Optional[Mapping[str, Any]] = None,
@@ -20,7 +20,7 @@ def count(
     Take `n` readings from a device
 
     Args:
-        detectors (List[Readable]): Readable devices to read
+        detectors (Set[Readable]): Readable devices to read
         num (int, optional): Number of readings to take. Defaults to 1.
         delay (Optional[Union[float, List[float]]], optional): Delay between readings.
                                                                Defaults to None.
@@ -34,13 +34,12 @@ def count(
     Yields:
         Iterator[MsgGenerator]: _description_
     """
-    plan_args = (
-        {  # If bp.count added delay to plan_args, we could remove all md handling
-            "detectors": list(map(repr, detectors)),
-            "num": num,
-            "delay": delay,
-        }
-    )
+    plan_args = {
+        # If bp.count added delay to plan_args, we could remove all md handling
+        "detectors": set(map(repr, detectors)),
+        "num": num,
+        "delay": delay,
+    }
 
     _md = {
         "plan_args": plan_args,

--- a/tests/plans/test_scanspec_metadata.py
+++ b/tests/plans/test_scanspec_metadata.py
@@ -57,7 +57,7 @@ def test_metadata_of_simple_spec(run_engine, x, loop):
     plan_args = start_document["plan_args"]
 
     assert len(plan_args) == 3
-    assert plan_args["detectors"] == [repr(det)]
+    assert plan_args["detectors"] == {repr(det)}
     assert plan_args["spec"] == repr(spec)
     assert plan_args["axes_to_move"] == {
         x.name: repr(x),
@@ -89,7 +89,7 @@ def test_metadata_of_spiral_spec(run_engine, x, y, loop):
     plan_args = start_document["plan_args"]
 
     assert len(plan_args) == 3
-    assert plan_args["detectors"] == [repr(det)]
+    assert plan_args["detectors"] == {repr(det)}
     assert plan_args["spec"] == repr(spec)
     assert plan_args["axes_to_move"] == {x.name: repr(x), y.name: repr(y)}
 


### PR DESCRIPTION
Change parameters in plans that are actualy Sets but listed as Lists to Sets so that the BlueAPI generated JSONSchema is more accurate.